### PR TITLE
docs: fix repository URLs and introduce ADR process

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security Vulnerability
-    url: https://github.com/zonblade/mini-gateway-rs/security/advisories/new
+    url: https://github.com/aula-id/mini-gateway-rs/security/advisories/new
     about: Please report security vulnerabilities through GitHub Security Advisories. Do not open a public issue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,10 +22,10 @@ This project adheres to the [Contributor Covenant Code of Conduct](CODE_OF_CONDU
 
 There are several ways to contribute to Mini Gateway:
 
-- **Report Bugs** -- Found something broken? Open a [Bug Report](https://github.com/zonblade/mini-gateway-rs/issues/new?template=bug_report.yml).
-- **Suggest Features** -- Have an idea? Submit a [Feature Request](https://github.com/zonblade/mini-gateway-rs/issues/new?template=feature_request.yml).
-- **Propose Milestone Work** -- Want to tackle a larger piece of the roadmap? Open a [Milestone Implementation](https://github.com/zonblade/mini-gateway-rs/issues/new?template=milestone_implementation.yml) proposal.
-- **Request Removal** -- Think something should be removed or deprecated? File a [Removal Request](https://github.com/zonblade/mini-gateway-rs/issues/new?template=request_removal.yml).
+- **Report Bugs** -- Found something broken? Open a [Bug Report](https://github.com/aula-id/mini-gateway-rs/issues/new?template=bug_report.yml).
+- **Suggest Features** -- Have an idea? Submit a [Feature Request](https://github.com/aula-id/mini-gateway-rs/issues/new?template=feature_request.yml).
+- **Propose Milestone Work** -- Want to tackle a larger piece of the roadmap? Open a [Milestone Implementation](https://github.com/aula-id/mini-gateway-rs/issues/new?template=milestone_implementation.yml) proposal.
+- **Request Removal** -- Think something should be removed or deprecated? File a [Removal Request](https://github.com/aula-id/mini-gateway-rs/issues/new?template=request_removal.yml).
 - **Report Security Vulnerabilities** -- Please see our [Security Policy](SECURITY.md). Do **not** open a public issue for security vulnerabilities.
 - **Improve Documentation** -- Typos, unclear explanations, missing docs -- all welcome.
 - **Submit Code** -- Bug fixes, performance improvements, new features.
@@ -55,7 +55,7 @@ Pull requests that appear to be predominantly AI-generated without disclosure wi
 
 ```bash
 # Clone the repository
-git clone https://github.com/zonblade/mini-gateway-rs.git
+git clone https://github.com/aula-id/mini-gateway-rs.git
 cd mini-gateway-rs
 
 # Build all workspace members

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Mini Gateway
 
 <p align="center">
-<img style="height:100%; width: 512px;" src="https://raw.githubusercontent.com/zonblade/mini-gateway-rs/main/assets/logo.png"/></br>
+<img style="height:100%; width: 512px;" src="https://raw.githubusercontent.com/aula-id/mini-gateway-rs/main/assets/logo.png"/></br>
 <span style="font-size:32px;">mini gateway</span></br>
 <span style="font-size:16px;">A very fast yet easy to control Gatway!</span>
 </p>
@@ -74,11 +74,11 @@ The architecture of the mini-gateway is currently simple and straightforward.
 
 ## Documentation
 
-api documentation can be found [here](https://github.com/zonblade/mini-gateway-rs/blob/main/router-api/README.md) , installation not yet ready but will be available both docker and apt-repository.
+api documentation can be found [here](https://github.com/aula-id/mini-gateway-rs/blob/main/router-api/README.md) , installation not yet ready but will be available both docker and apt-repository.
 
 ## Getting Started
 
-for manual build guideline please refer to each dockerfiles in [here](https://github.com/zonblade/mini-gateway-rs/tree/main/build-docker) but we provide docker and binary:
+for manual build guideline please refer to each dockerfiles in [here](https://github.com/aula-id/mini-gateway-rs/tree/main/build-docker) but we provide docker and binary:
 - for the docker you can get it [here on dockerhub](https://hub.docker.com/r/zonblade/mini-gateway/tags)
 - for the binary you can check our github release 
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ The Mini Gateway team takes security vulnerabilities seriously. We appreciate yo
 
 To report a security vulnerability, please use one of the following methods:
 
-1. **GitHub Private Vulnerability Reporting** -- Use the [Security Advisories](https://github.com/zonblade/mini-gateway-rs/security/advisories/new) feature to privately report the vulnerability.
+1. **GitHub Private Vulnerability Reporting** -- Use the [Security Advisories](https://github.com/aula-id/mini-gateway-rs/security/advisories/new) feature to privately report the vulnerability.
 2. **Email** -- If private vulnerability reporting is not available, open a PR with the prefix `REPORT:` containing only the necessary details.
 
 ### What to Include

--- a/build-apt/README.md
+++ b/build-apt/README.md
@@ -8,14 +8,14 @@ This directory contains files for installing GWRS Mini-Gateway components as Deb
 
 ```bash
 # Add the repository and install
-curl -s https://raw.githubusercontent.com/zonblade/mini-gateway-rs/main/build-apt/install.sh | sudo bash
+curl -s https://raw.githubusercontent.com/aula-id/mini-gateway-rs/main/build-apt/install.sh | sudo bash
 ```
 
 ### Manual Installation
 
 1. Download the installation script:
    ```bash
-   wget https://raw.githubusercontent.com/zonblade/mini-gateway-rs/main/build-apt/install.sh
+   wget https://raw.githubusercontent.com/aula-id/mini-gateway-rs/main/build-apt/install.sh
    ```
 
 2. Make it executable:

--- a/docs/adr/2026-03-29-adr-process.md
+++ b/docs/adr/2026-03-29-adr-process.md
@@ -1,0 +1,76 @@
+# ADR: ADR Process
+
+## Date
+
+2026-03-29
+
+## Context
+
+As we begin contributing to the mini-gateway-rs CLI (completing the Control Panel and Live Monitoring roadmap items), we need a structured way to document architectural decisions. The project has several non-obvious design choices (custom Pingora fork, UDP logging with accepted packet loss, custom ProTTP protocol) but no formal record of why these decisions were made.
+
+Without documented decisions, contributors risk re-litigating settled questions or making changes that conflict with the original design intent. ADRs provide a lightweight way to capture the "why" behind architectural choices so that future contributors can understand the reasoning.
+
+## Architecture
+
+```mermaid
+stateDiagram-v2
+    [*] --> Active : Merged via PR
+    Active --> Superseded : Replaced by new ADR
+    Active --> Deprecated : No longer relevant
+    Superseded --> [*]
+    Deprecated --> [*]
+```
+
+## Decision
+
+We adopt Architecture Decision Records following the Michael Nygard format, extended with mandatory Mermaid diagrams for any decision involving component interaction or data flow.
+
+### Format
+
+Each ADR is a Markdown file in `docs/adr/` named `YYYY-MM-DD-short-title.md` using the creation date. This avoids merge conflicts when multiple contributors create ADRs simultaneously. The file follows the template at `docs/adr/template.md` with these sections:
+
+- **Date**: When the ADR was created (YYYY-MM-DD)
+- **Context**: The problem or situation driving the decision
+- **Architecture**: Mermaid diagram(s) visualizing the relevant structure or flow
+- **Decision**: What we decided and why
+- **Consequences**: Positive, negative, and risk impacts
+- **Alternatives Considered**: Other options and why they were rejected
+- **References**: Links to related ADRs, issues, or external resources
+
+### Rules
+
+1. ADRs are named by date: `YYYY-MM-DD-short-title.md`. If multiple ADRs share a date, use distinct titles.
+2. An ADR is considered active once its PR is merged. The PR review process serves as the approval mechanism.
+3. ADRs are immutable once merged. New decisions that override old ones create a new ADR and add a "Superseded by [new ADR]" note at the top of the original.
+4. Mermaid diagrams are required for any ADR that involves component interaction, data flow, or state transitions.
+5. The `docs/adr/README.md` index must be updated when any ADR is added.
+
+## Consequences
+
+### Positive
+
+- Architectural decisions are discoverable and searchable in the repository.
+- New contributors can understand the "why" behind design choices without asking the original author.
+- Mermaid diagrams render natively on GitHub, providing visual context alongside text.
+
+### Negative
+
+- Adds a documentation step before implementation, which costs time upfront.
+- ADRs can become stale if not maintained when decisions are revisited.
+
+### Risks
+
+- Over-documentation: not every small decision needs an ADR. Reserve them for decisions that affect module boundaries, dependency choices, protocol design, or data flow.
+
+## Alternatives Considered
+
+**No formal process**: Rely on commit messages and PR descriptions. Rejected because these are scattered and hard to discover after the fact.
+
+**Wiki-based documentation**: Use GitHub Wiki. Rejected because it lives outside the repository, cannot be reviewed in PRs, and is easy to lose sync with the code.
+
+**RFCs**: More heavyweight than needed for this project's size and contributor count.
+
+## References
+
+- [Michael Nygard's ADR format](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions)
+- [Mermaid diagram syntax](https://mermaid.js.org/intro/)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,15 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADR) for the mini-gateway-rs project.
+
+ADRs document significant architectural decisions along with their context, rationale, and consequences. Each ADR uses Mermaid diagrams to visualize component interactions and data flows.
+
+## Index
+
+| ADR | Title | Date |
+|-----|-------|------|
+| [2026-03-29-adr-process](2026-03-29-adr-process.md) | ADR Process | 2026-03-29 |
+
+## How to Contribute
+
+See [2026-03-29-adr-process](2026-03-29-adr-process.md) for the process and template used to create new ADRs.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,44 @@
+# ADR-NNNN: Title
+
+## Date
+
+YYYY-MM-DD
+
+## Context
+
+What is the issue that we're seeing that motivates this decision or change?
+
+## Architecture
+
+> Mermaid diagram(s) illustrating the component interaction, data flow, or state transitions relevant to this decision. Choose the appropriate diagram type(s): component, sequence, flowchart, or state diagram.
+
+```mermaid
+graph TD
+    A[Component] --> B[Component]
+```
+
+## Decision
+
+What is the change that we're proposing and/or doing?
+
+## Consequences
+
+### Positive
+
+- ...
+
+### Negative
+
+- ...
+
+### Risks
+
+- ...
+
+## Alternatives Considered
+
+What other options were evaluated and why were they rejected?
+
+## References
+
+- Links to related ADRs, issues, or external resources.


### PR DESCRIPTION
## Summary

- Fix repository URLs across documentation (CONTRIBUTING.md, SECURITY.md, README.md, build-apt/README.md, issue template config) from `zonblade/mini-gateway-rs` to `aula-id/mini-gateway-rs`
- Introduce Architecture Decision Records (ADR) with date-based naming (`YYYY-MM-DD-title.md`) and Mermaid diagrams

## Why ADR?

The project has several non-obvious architectural decisions (custom Pingora fork, UDP-based logging with accepted packet loss, custom ProTTP control protocol) but no formal record of why these choices were made. Without documented decisions, contributors risk re-litigating settled questions or making changes that conflict with the original design intent.

ADRs provide a lightweight way to capture the "why" behind architectural choices. Each ADR includes Mermaid diagrams that render natively on GitHub, giving visual context for component interactions and data flows.

Date-based naming (`YYYY-MM-DD-title.md`) is used instead of sequential numbering to avoid merge conflicts when multiple contributors create ADRs simultaneously.

## AI Disclosure

AI tools (Claude) were used for assistance. All changes were reviewed.

## Test plan

- [x] Verify all documentation links point to correct repository